### PR TITLE
Fix choppy AppBar collapsing with RecyclerView (fixed)

### DIFF
--- a/smooth-app-bar-layout/src/main/java/me/henrytao/smoothappbarlayout/base/ObservableRecyclerView.java
+++ b/smooth-app-bar-layout/src/main/java/me/henrytao/smoothappbarlayout/base/ObservableRecyclerView.java
@@ -62,8 +62,22 @@ public class ObservableRecyclerView implements Observer {
       @Override
       public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
         if (mOnScrollListener != null) {
+          final int verticalScrollOffset;
+
+          RecyclerView.LayoutManager manager = mRecyclerView.getLayoutManager();
+          if (manager instanceof LinearLayoutManager) {
+            RecyclerView.ViewHolder viewHolder = mRecyclerView.findViewHolderForAdapterPosition(0);
+            if (viewHolder != null) {
+              verticalScrollOffset = mRecyclerView.getPaddingTop() - viewHolder.itemView.getTop();
+            } else {
+              verticalScrollOffset = recyclerView.computeVerticalScrollOffset();
+            }
+          } else {
+            verticalScrollOffset = recyclerView.computeVerticalScrollOffset();
+          }
+          
           mOnScrollListener.onScrollChanged(recyclerView,
-              recyclerView.computeHorizontalScrollOffset(), recyclerView.computeVerticalScrollOffset(),
+              recyclerView.computeHorizontalScrollOffset(), verticalScrollOffset,
               dx, dy,
               recyclerView.getLayoutManager().findViewByPosition(HEADER_VIEW_POSITION) != null);
         }


### PR DESCRIPTION
computeVerticalScrollOffset doesn't return accurate values - they can jump by 30px or more if all items don't have the same height. If possible, get the first ViewHolder and get it's top position and use it as the scroll offset.
This time with better indentation.
